### PR TITLE
Make dev-env consume mocked data

### DIFF
--- a/nutridine/package.json
+++ b/nutridine/package.json
@@ -45,7 +45,8 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "lint": "eslint ."
   },
   "eslintConfig": {
     "extends": [

--- a/nutridine/src/constants/mockData/detailedMeal.js
+++ b/nutridine/src/constants/mockData/detailedMeal.js
@@ -1,0 +1,68 @@
+const mockDetailedMeal = {
+  food_name: "Placeholder Meal Name",
+  brand_name: "Placeholder Brand Name",
+  serving_qty: 1,
+  serving_unit: "bottle",
+  serving_weight_grams: 226,
+  nf_metric_qty: 591,
+  nf_metric_uom: "ml",
+  nf_calories: 348,
+  nf_total_fat: 2,
+  nf_saturated_fat: null,
+  nf_cholesterol: null,
+  nf_sodium: 70,
+  nf_total_carbohydrate: 39,
+  nf_dietary_fiber: null,
+  nf_sugars: null,
+  nf_protein: 0,
+  nf_potassium: null,
+  nf_p: null,
+  full_nutrients: [
+    {
+      attr_id: 203,
+      value: 1,
+    },
+    {
+      attr_id: 204,
+      value: 2,
+    },
+    {
+      attr_id: 205,
+      value: 3,
+    },
+    {
+      attr_id: 208,
+      value: 4,
+    },
+    {
+      attr_id: 307,
+      value: 70,
+    },
+  ],
+  nix_brand_name: "Coke",
+  nix_brand_id: "51db3801176fe9790a89ae0b",
+  nix_item_name: "Diet Cola",
+  nix_item_id: "51d2fae7cc9bff111580d8d8",
+  metadata: {},
+  source: 8,
+  ndb_no: null,
+  tags: null,
+  alt_measures: null,
+  lat: null,
+  lng: null,
+  photo: {
+    thumb:
+      "https://nutritionix-api.s3.amazonaws.com/5b5c17c429f162275dc922b0.jpeg",
+    highres: null,
+    is_user_uploaded: false,
+  },
+  note: null,
+  class_code: null,
+  brick_code: null,
+  tag_id: null,
+  updated_at: "2022-06-22T03:14:26+00:00",
+  nf_ingredient_statement:
+    "Carbonated Water, Caramel Color, Aspartame, Phosphoric Acid, Potassium Benzoate (to Protect Taste), Natural Flavors, Citric Acid, Caffeine.",
+};
+
+export default mockDetailedMeal;

--- a/nutridine/src/constants/mockData/meals.js
+++ b/nutridine/src/constants/mockData/meals.js
@@ -1,0 +1,1510 @@
+const mockMeals = [
+  {
+    food_name: "New York Cheesecake",
+    nix_brand_id: "521b95434a56d006cae29705",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "Boston Pizza",
+    full_nutrients: [
+      {
+        value: 11,
+        attr_id: 203,
+      },
+      {
+        value: 37,
+        attr_id: 204,
+      },
+      {
+        value: 54,
+        attr_id: 205,
+      },
+      {
+        value: 580,
+        attr_id: 208,
+      },
+      {
+        value: 37,
+        attr_id: 269,
+      },
+      {
+        value: 1,
+        attr_id: 291,
+      },
+      {
+        value: 130,
+        attr_id: 301,
+      },
+      {
+        value: 1.8,
+        attr_id: 303,
+      },
+      {
+        value: 360,
+        attr_id: 307,
+      },
+      {
+        value: 0,
+        attr_id: 318,
+      },
+      {
+        value: 0,
+        attr_id: 401,
+      },
+      {
+        value: 165,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 21,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: null,
+    nix_item_id: "53444b4a9a631f1645ecf87a",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "Boston Pizza New York Cheesecake",
+    serving_qty: 1,
+    nf_calories: 580,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "New Caesar McWrap with Crispy Chicken",
+    nix_brand_id: "61e5ddbdac32a8e539450cc3",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "McDonald's Canada",
+    full_nutrients: [
+      {
+        value: 30,
+        attr_id: 203,
+      },
+      {
+        value: 27,
+        attr_id: 204,
+      },
+      {
+        value: 52,
+        attr_id: 205,
+      },
+      {
+        value: 570,
+        attr_id: 208,
+      },
+      {
+        value: 3,
+        attr_id: 269,
+      },
+      {
+        value: 7,
+        attr_id: 291,
+      },
+      {
+        value: 960,
+        attr_id: 307,
+      },
+      {
+        value: 75,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 7,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: null,
+    nix_item_id: "d3ea44147a169cc9b4e535c6",
+    nf_metric_qty: null,
+    serving_unit: "grams",
+    brand_name_item_name:
+      "McDonald's Canada New Caesar McWrap with Crispy Chicken",
+    serving_qty: 226,
+    nf_calories: 570,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Caesar Wings, BBQ",
+    nix_brand_id: "513fbc1283aa2dc80c000030",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "Little Caesars Pizza",
+    full_nutrients: [
+      {
+        value: 48,
+        attr_id: 203,
+      },
+      {
+        value: 35,
+        attr_id: 204,
+      },
+      {
+        value: 32,
+        attr_id: 205,
+      },
+      {
+        value: 620,
+        attr_id: 208,
+      },
+      {
+        value: 24,
+        attr_id: 269,
+      },
+      {
+        value: 0,
+        attr_id: 291,
+      },
+      {
+        value: 2300,
+        attr_id: 307,
+      },
+      {
+        value: 285,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 9,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: null,
+    nix_item_id: "513fc997927da70408003f39",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "Little Caesars Pizza Caesar Wings, BBQ",
+    serving_qty: 1,
+    nf_calories: 620,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Meek Myrtle Chicken Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 39,
+        attr_id: 203,
+      },
+      {
+        value: 37,
+        attr_id: 204,
+      },
+      {
+        value: 36,
+        attr_id: 205,
+      },
+      {
+        value: 640,
+        attr_id: 208,
+      },
+      {
+        value: 12,
+        attr_id: 269,
+      },
+      {
+        value: 4,
+        attr_id: 291,
+      },
+      {
+        value: 325,
+        attr_id: 301,
+      },
+      {
+        value: 3.6,
+        attr_id: 303,
+      },
+      {
+        value: 2370,
+        attr_id: 307,
+      },
+      {
+        value: 1000,
+        attr_id: 318,
+      },
+      {
+        value: 6,
+        attr_id: 401,
+      },
+      {
+        value: 120,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 9,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 417,
+    nix_item_id: "513fc9ca673c4fbc26004c4f",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "De Dutch Pannekoek House Meek Myrtle Chicken Burger",
+    serving_qty: 1,
+    nf_calories: 640,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Simple Simon Chicken Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 39,
+        attr_id: 203,
+      },
+      {
+        value: 36,
+        attr_id: 204,
+      },
+      {
+        value: 30,
+        attr_id: 205,
+      },
+      {
+        value: 600,
+        attr_id: 208,
+      },
+      {
+        value: 10,
+        attr_id: 269,
+      },
+      {
+        value: 3,
+        attr_id: 291,
+      },
+      {
+        value: 260,
+        attr_id: 301,
+      },
+      {
+        value: 3.6,
+        attr_id: 303,
+      },
+      {
+        value: 2390,
+        attr_id: 307,
+      },
+      {
+        value: 1000,
+        attr_id: 318,
+      },
+      {
+        value: 1.2,
+        attr_id: 401,
+      },
+      {
+        value: 115,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 9,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 372,
+    nix_item_id: "513fc9ca673c4fbc26004c53",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name:
+      "De Dutch Pannekoek House Simple Simon Chicken Burger",
+    serving_qty: 1,
+    nf_calories: 600,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Canadian Chicken Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 38,
+        attr_id: 203,
+      },
+      {
+        value: 36,
+        attr_id: 204,
+      },
+      {
+        value: 29,
+        attr_id: 205,
+      },
+      {
+        value: 590,
+        attr_id: 208,
+      },
+      {
+        value: 10,
+        attr_id: 269,
+      },
+      {
+        value: 2,
+        attr_id: 291,
+      },
+      {
+        value: 260,
+        attr_id: 301,
+      },
+      {
+        value: 3.6,
+        attr_id: 303,
+      },
+      {
+        value: 2510,
+        attr_id: 307,
+      },
+      {
+        value: 1000,
+        attr_id: 318,
+      },
+      {
+        value: 0,
+        attr_id: 401,
+      },
+      {
+        value: 115,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 9,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 351,
+    nix_item_id: "513fc9ca673c4fbc26004c47",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "De Dutch Pannekoek House Canadian Chicken Burger",
+    serving_qty: 1,
+    nf_calories: 590,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Gentle John Chicken Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 44,
+        attr_id: 203,
+      },
+      {
+        value: 40,
+        attr_id: 204,
+      },
+      {
+        value: 30,
+        attr_id: 205,
+      },
+      {
+        value: 660,
+        attr_id: 208,
+      },
+      {
+        value: 10,
+        attr_id: 269,
+      },
+      {
+        value: 2,
+        attr_id: 291,
+      },
+      {
+        value: 260,
+        attr_id: 301,
+      },
+      {
+        value: 4.5,
+        attr_id: 303,
+      },
+      {
+        value: 2570,
+        attr_id: 307,
+      },
+      {
+        value: 1500,
+        attr_id: 318,
+      },
+      {
+        value: 0,
+        attr_id: 401,
+      },
+      {
+        value: 330,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 10,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 401,
+    nix_item_id: "513fc9ca673c4fbc26004c4a",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "De Dutch Pannekoek House Gentle John Chicken Burger",
+    serving_qty: 1,
+    nf_calories: 660,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Humble Helen Chicken Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 43,
+        attr_id: 203,
+      },
+      {
+        value: 50,
+        attr_id: 204,
+      },
+      {
+        value: 36,
+        attr_id: 205,
+      },
+      {
+        value: 780,
+        attr_id: 208,
+      },
+      {
+        value: 13,
+        attr_id: 269,
+      },
+      {
+        value: 4,
+        attr_id: 291,
+      },
+      {
+        value: 520,
+        attr_id: 301,
+      },
+      {
+        value: 6.3,
+        attr_id: 303,
+      },
+      {
+        value: 2630,
+        attr_id: 307,
+      },
+      {
+        value: 1000,
+        attr_id: 318,
+      },
+      {
+        value: 6,
+        attr_id: 401,
+      },
+      {
+        value: 150,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 14,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 458,
+    nix_item_id: "513fc9ca673c4fbc26004c4d",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name:
+      "De Dutch Pannekoek House Humble Helen Chicken Burger",
+    serving_qty: 1,
+    nf_calories: 780,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Mediterranean Chicken Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8e",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "White Spot Restaurants",
+    full_nutrients: [
+      {
+        value: 37,
+        attr_id: 203,
+      },
+      {
+        value: 22,
+        attr_id: 204,
+      },
+      {
+        value: 47,
+        attr_id: 205,
+      },
+      {
+        value: 520,
+        attr_id: 208,
+      },
+      {
+        value: 11,
+        attr_id: 269,
+      },
+      {
+        value: 1,
+        attr_id: 291,
+      },
+      {
+        value: 130,
+        attr_id: 301,
+      },
+      {
+        value: 10.8,
+        attr_id: 303,
+      },
+      {
+        value: 1440,
+        attr_id: 307,
+      },
+      {
+        value: 1000,
+        attr_id: 318,
+      },
+      {
+        value: 30,
+        attr_id: 401,
+      },
+      {
+        value: 100,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 5,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 351,
+    nix_item_id: "513fc9ca673c4fbc26004dc4",
+    nf_metric_qty: null,
+    serving_unit: "serving",
+    brand_name_item_name: "White Spot Restaurants Mediterranean Chicken Burger",
+    serving_qty: 1,
+    nf_calories: 520,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Papa Burger",
+    nix_brand_id: "5e6a5d8c93bdd7923d93ca1c",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "A&W (Canada)",
+    full_nutrients: [
+      {
+        value: 33,
+        attr_id: 203,
+      },
+      {
+        value: 33,
+        attr_id: 204,
+      },
+      {
+        value: 38,
+        attr_id: 205,
+      },
+      {
+        value: 580,
+        attr_id: 208,
+      },
+      {
+        value: 9,
+        attr_id: 269,
+      },
+      {
+        value: 1,
+        attr_id: 291,
+      },
+      {
+        value: 52,
+        attr_id: 301,
+      },
+      {
+        value: 6.3,
+        attr_id: 303,
+      },
+      {
+        value: 910,
+        attr_id: 307,
+      },
+      {
+        value: 0,
+        attr_id: 318,
+      },
+      {
+        value: 1.2,
+        attr_id: 401,
+      },
+      {
+        value: 95,
+        attr_id: 601,
+      },
+      {
+        value: 1,
+        attr_id: 605,
+      },
+      {
+        value: 13,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 230,
+    nix_item_id: "d3ea727417529468271141d4",
+    nf_metric_qty: null,
+    serving_unit: "burger",
+    brand_name_item_name: "A&W (Canada) Papa Burger",
+    serving_qty: 1,
+    nf_calories: 580,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Halibut Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 45,
+        attr_id: 203,
+      },
+      {
+        value: 34,
+        attr_id: 204,
+      },
+      {
+        value: 36,
+        attr_id: 205,
+      },
+      {
+        value: 640,
+        attr_id: 208,
+      },
+      {
+        value: 12,
+        attr_id: 269,
+      },
+      {
+        value: 5,
+        attr_id: 291,
+      },
+      {
+        value: 130,
+        attr_id: 301,
+      },
+      {
+        value: 5.4,
+        attr_id: 303,
+      },
+      {
+        value: 630,
+        attr_id: 307,
+      },
+      {
+        value: 1750,
+        attr_id: 318,
+      },
+      {
+        value: 18,
+        attr_id: 401,
+      },
+      {
+        value: 70,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 4,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 458,
+    nix_item_id: "513fc9ca673c4fbc26004c4b",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "De Dutch Pannekoek House Halibut Burger",
+    serving_qty: 1,
+    nf_calories: 640,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Canadian Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 32,
+        attr_id: 203,
+      },
+      {
+        value: 53,
+        attr_id: 204,
+      },
+      {
+        value: 30,
+        attr_id: 205,
+      },
+      {
+        value: 710,
+        attr_id: 208,
+      },
+      {
+        value: 10,
+        attr_id: 269,
+      },
+      {
+        value: 3,
+        attr_id: 291,
+      },
+      {
+        value: 260,
+        attr_id: 301,
+      },
+      {
+        value: 5.4,
+        attr_id: 303,
+      },
+      {
+        value: 2350,
+        attr_id: 307,
+      },
+      {
+        value: 1000,
+        attr_id: 318,
+      },
+      {
+        value: 0,
+        attr_id: 401,
+      },
+      {
+        value: 90,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 16,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 323,
+    nix_item_id: "513fc9ca673c4fbc26004c46",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "De Dutch Pannekoek House Canadian Burger",
+    serving_qty: 1,
+    nf_calories: 710,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Plain Jane Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 37,
+        attr_id: 203,
+      },
+      {
+        value: 48,
+        attr_id: 204,
+      },
+      {
+        value: 26,
+        attr_id: 205,
+      },
+      {
+        value: 680,
+        attr_id: 208,
+      },
+      {
+        value: 6,
+        attr_id: 269,
+      },
+      {
+        value: 2,
+        attr_id: 291,
+      },
+      {
+        value: 325,
+        attr_id: 301,
+      },
+      {
+        value: 6.3,
+        attr_id: 303,
+      },
+      {
+        value: 2050,
+        attr_id: 307,
+      },
+      {
+        value: 200,
+        attr_id: 318,
+      },
+      {
+        value: 0,
+        attr_id: 401,
+      },
+      {
+        value: 115,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 19,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 268,
+    nix_item_id: "513fc9ca673c4fbc26004c50",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "De Dutch Pannekoek House Plain Jane Burger",
+    serving_qty: 1,
+    nf_calories: 680,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "BC Chicken Burger without Sauce",
+    nix_brand_id: "513fbc1283aa2dc80c000b8e",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "White Spot Restaurants",
+    full_nutrients: [
+      {
+        value: 44,
+        attr_id: 203,
+      },
+      {
+        value: 20,
+        attr_id: 204,
+      },
+      {
+        value: 52,
+        attr_id: 205,
+      },
+      {
+        value: 570,
+        attr_id: 208,
+      },
+      {
+        value: 8,
+        attr_id: 269,
+      },
+      {
+        value: 2,
+        attr_id: 291,
+      },
+      {
+        value: 325,
+        attr_id: 301,
+      },
+      {
+        value: 4.5,
+        attr_id: 303,
+      },
+      {
+        value: 870,
+        attr_id: 307,
+      },
+      {
+        value: 750,
+        attr_id: 318,
+      },
+      {
+        value: 9,
+        attr_id: 401,
+      },
+      {
+        value: 95,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 6,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 326,
+    nix_item_id: "513fc9ca673c4fbc26004dbc",
+    nf_metric_qty: null,
+    serving_unit: "serving",
+    brand_name_item_name:
+      "White Spot Restaurants BC Chicken Burger without Sauce",
+    serving_qty: 1,
+    nf_calories: 570,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Meek Myrtle Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 33,
+        attr_id: 203,
+      },
+      {
+        value: 54,
+        attr_id: 204,
+      },
+      {
+        value: 37,
+        attr_id: 205,
+      },
+      {
+        value: 760,
+        attr_id: 208,
+      },
+      {
+        value: 12,
+        attr_id: 269,
+      },
+      {
+        value: 4,
+        attr_id: 291,
+      },
+      {
+        value: 325,
+        attr_id: 301,
+      },
+      {
+        value: 5.4,
+        attr_id: 303,
+      },
+      {
+        value: 2210,
+        attr_id: 307,
+      },
+      {
+        value: 1000,
+        attr_id: 318,
+      },
+      {
+        value: 6,
+        attr_id: 401,
+      },
+      {
+        value: 95,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 16,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 389,
+    nix_item_id: "513fc9ca673c4fbc26004c4e",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "De Dutch Pannekoek House Meek Myrtle Burger",
+    serving_qty: 1,
+    nf_calories: 760,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Simple Simon Burger",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 33,
+        attr_id: 203,
+      },
+      {
+        value: 53,
+        attr_id: 204,
+      },
+      {
+        value: 30,
+        attr_id: 205,
+      },
+      {
+        value: 720,
+        attr_id: 208,
+      },
+      {
+        value: 10,
+        attr_id: 269,
+      },
+      {
+        value: 3,
+        attr_id: 291,
+      },
+      {
+        value: 260,
+        attr_id: 301,
+      },
+      {
+        value: 5.4,
+        attr_id: 303,
+      },
+      {
+        value: 2230,
+        attr_id: 307,
+      },
+      {
+        value: 1000,
+        attr_id: 318,
+      },
+      {
+        value: 1.2,
+        attr_id: 401,
+      },
+      {
+        value: 90,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 16,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 344,
+    nix_item_id: "513fc9ca673c4fbc26004c52",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name: "De Dutch Pannekoek House Simple Simon Burger",
+    serving_qty: 1,
+    nf_calories: 720,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Meaty Deep Dish Pizza Slice",
+    nix_brand_id: "513fbc1283aa2dc80c000009",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "Pizza Hut",
+    full_nutrients: [
+      {
+        value: 26,
+        attr_id: 203,
+      },
+      {
+        value: 31,
+        attr_id: 204,
+      },
+      {
+        value: 37,
+        attr_id: 205,
+      },
+      {
+        value: 530,
+        attr_id: 208,
+      },
+      {
+        value: 7,
+        attr_id: 269,
+      },
+      {
+        value: 4,
+        attr_id: 291,
+      },
+      {
+        value: 1210,
+        attr_id: 307,
+      },
+      {
+        value: 80,
+        attr_id: 601,
+      },
+      {
+        value: 0.5,
+        attr_id: 605,
+      },
+      {
+        value: 14,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: null,
+    nix_item_id: "bd9d361419cfcdb44dbec551",
+    nf_metric_qty: null,
+    serving_unit: "Slice",
+    brand_name_item_name: "Pizza Hut Meaty Deep Dish Pizza Slice",
+    serving_qty: 1,
+    nf_calories: 530,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "BLT with Grilled Chicken",
+    nix_brand_id: "61e5ddbdac32a8e539450cc3",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "McDonald's Canada",
+    full_nutrients: [
+      {
+        value: 38,
+        attr_id: 203,
+      },
+      {
+        value: 25,
+        attr_id: 204,
+      },
+      {
+        value: 44,
+        attr_id: 205,
+      },
+      {
+        value: 560,
+        attr_id: 208,
+      },
+      {
+        value: 7,
+        attr_id: 269,
+      },
+      {
+        value: 2,
+        attr_id: 291,
+      },
+      {
+        value: 1100,
+        attr_id: 307,
+      },
+      {
+        value: 140,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 7,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: null,
+    nix_item_id: "d3ea441420bed04c13901938",
+    nf_metric_qty: null,
+    serving_unit: "grams",
+    brand_name_item_name: "McDonald's Canada BLT with Grilled Chicken",
+    serving_qty: 231,
+    nf_calories: 560,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Chicken & Bacon McWrap with Crispy Chicken",
+    nix_brand_id: "61e5ddbdac32a8e539450cc3",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "McDonald's Canada",
+    full_nutrients: [
+      {
+        value: 29,
+        attr_id: 203,
+      },
+      {
+        value: 32,
+        attr_id: 204,
+      },
+      {
+        value: 50,
+        attr_id: 205,
+      },
+      {
+        value: 600,
+        attr_id: 208,
+      },
+      {
+        value: 3,
+        attr_id: 269,
+      },
+      {
+        value: 7,
+        attr_id: 291,
+      },
+      {
+        value: 860,
+        attr_id: 307,
+      },
+      {
+        value: 75,
+        attr_id: 601,
+      },
+      {
+        value: 0,
+        attr_id: 605,
+      },
+      {
+        value: 7,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: null,
+    nix_item_id: "d3ea4414be0f25026c7c1171",
+    nf_metric_qty: null,
+    serving_unit: "grams",
+    brand_name_item_name:
+      "McDonald's Canada Chicken & Bacon McWrap with Crispy Chicken",
+    serving_qty: 237,
+    nf_calories: 600,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+  {
+    food_name: "Smoked Salmon, Red Onion & Brie Whole Grain",
+    nix_brand_id: "513fbc1283aa2dc80c000b8a",
+    photo: {
+      thumb: "https://d2eawub7utcl6.cloudfront.net/images/nix-apple-grey.png",
+      highres: null,
+      is_user_uploaded: false,
+    },
+    brand_name: "De Dutch Pannekoek House",
+    full_nutrients: [
+      {
+        value: 26,
+        attr_id: 203,
+      },
+      {
+        value: 29,
+        attr_id: 204,
+      },
+      {
+        value: 45,
+        attr_id: 205,
+      },
+      {
+        value: 530,
+        attr_id: 208,
+      },
+      {
+        value: 6,
+        attr_id: 269,
+      },
+      {
+        value: 6,
+        attr_id: 291,
+      },
+      {
+        value: 195,
+        attr_id: 301,
+      },
+      {
+        value: 5.4,
+        attr_id: 303,
+      },
+      {
+        value: 1380,
+        attr_id: 307,
+      },
+      {
+        value: 500,
+        attr_id: 318,
+      },
+      {
+        value: 3.6,
+        attr_id: 401,
+      },
+      {
+        value: 85,
+        attr_id: 601,
+      },
+      {
+        value: 0.5,
+        attr_id: 605,
+      },
+      {
+        value: 17,
+        attr_id: 606,
+      },
+    ],
+    serving_weight_grams: 210,
+    nix_item_id: "513fc9ca673c4fbc26004b73",
+    nf_metric_qty: null,
+    serving_unit: "Serving",
+    brand_name_item_name:
+      "De Dutch Pannekoek House Smoked Salmon, Red Onion & Brie Whole Grain",
+    serving_qty: 1,
+    nf_calories: 530,
+    region: 1,
+    brand_type: 1,
+    nf_metric_uom: null,
+    locale: "en_US",
+  },
+];
+
+export default mockMeals;

--- a/nutridine/src/hooks/useMealById.js
+++ b/nutridine/src/hooks/useMealById.js
@@ -1,73 +1,6 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
-
-// To be used in the event that the Nutritionix API is not available (or we have exceeded rate limit)
-const placeholderDetailedMeal = {
-  food_name: "Placeholder Meal Name",
-  brand_name: "Placeholder Brand Name",
-  serving_qty: 1,
-  serving_unit: "bottle",
-  serving_weight_grams: 226,
-  nf_metric_qty: 591,
-  nf_metric_uom: "ml",
-  nf_calories: 348,
-  nf_total_fat: 2,
-  nf_saturated_fat: null,
-  nf_cholesterol: null,
-  nf_sodium: 70,
-  nf_total_carbohydrate: 39,
-  nf_dietary_fiber: null,
-  nf_sugars: null,
-  nf_protein: 0,
-  nf_potassium: null,
-  nf_p: null,
-  full_nutrients: [
-    {
-      attr_id: 203,
-      value: 1,
-    },
-    {
-      attr_id: 204,
-      value: 2,
-    },
-    {
-      attr_id: 205,
-      value: 3,
-    },
-    {
-      attr_id: 208,
-      value: 4,
-    },
-    {
-      attr_id: 307,
-      value: 70,
-    },
-  ],
-  nix_brand_name: "Coke",
-  nix_brand_id: "51db3801176fe9790a89ae0b",
-  nix_item_name: "Diet Cola",
-  nix_item_id: "51d2fae7cc9bff111580d8d8",
-  metadata: {},
-  source: 8,
-  ndb_no: null,
-  tags: null,
-  alt_measures: null,
-  lat: null,
-  lng: null,
-  photo: {
-    thumb:
-      "https://nutritionix-api.s3.amazonaws.com/5b5c17c429f162275dc922b0.jpeg",
-    highres: null,
-    is_user_uploaded: false,
-  },
-  note: null,
-  class_code: null,
-  brick_code: null,
-  tag_id: null,
-  updated_at: "2022-06-22T03:14:26+00:00",
-  nf_ingredient_statement:
-    "Carbonated Water, Caramel Color, Aspartame, Phosphoric Acid, Potassium Benzoate (to Protect Taste), Natural Flavors, Citric Acid, Caffeine.",
-};
+import mockDetailedMeal from "../constants/mockData/detailedMeal";
 
 const useMealById = ({ nix_item_id }) => {
   const [detailedMeal, setDetailedMeal] = useState(null);
@@ -77,7 +10,10 @@ const useMealById = ({ nix_item_id }) => {
   /* NutritionIX gives us very limited /search/item endpoint calls. To prevent wasting
   API calls, set IS_TESTING=true while in dev mode to skip the api call and use 
   the placeholder data (which is the same structure)*/
-  const IS_TESTING = true;
+
+  /** Due to limited NutritionIX API calls, this will make our app consumer fake data
+   * while in development mode. The production app wll use the actual API call. */
+  const IS_TESTING = process.env.REACT_APP_DEVELOPMENT_MODE ?? true;
 
   useEffect(() => {
     const apiKey = process.env.REACT_APP_NUTRITIONIX_API_KEY;
@@ -93,7 +29,6 @@ const useMealById = ({ nix_item_id }) => {
               "Content-Type": "application/json",
               "x-app-id": appId,
               "x-app-key": apiKey,
-              "x-remote-user-id": 0,
             },
           }
         );
@@ -106,7 +41,7 @@ const useMealById = ({ nix_item_id }) => {
     };
 
     if (IS_TESTING) {
-      setDetailedMeal(placeholderDetailedMeal);
+      setDetailedMeal(mockDetailedMeal);
       setLoading(false);
       setError(false);
     } else {

--- a/nutridine/src/hooks/useMealsByMacros.js
+++ b/nutridine/src/hooks/useMealsByMacros.js
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import axios from "axios";
 import brandIds from "../constants/brandIds";
+import mockMeals from "../constants/mockData/meals";
 
 export const fetchMealsByMacros = async ({
   query,
@@ -15,6 +16,14 @@ export const fetchMealsByMacros = async ({
 }) => {
   const apiKey = process.env.REACT_APP_NUTRITIONIX_API_KEY;
   const appId = process.env.REACT_APP_NUTRITIONIX_APP_ID;
+
+  /** Due to limited NutritionIX API calls, this will make our app consumer fake data
+   * while in development mode. The production app wll use the actual API call. */
+  const IS_TESTING = process.env.REACT_APP_DEVELOPMENT_MODE ?? true;
+
+  if (IS_TESTING) {
+    return { data: mockMeals, error: null };
+  }
 
   try {
     console.log("useMealsByMacros is fetching...");


### PR DESCRIPTION
This PR adds the `REACT_APP_DEVELOPMENT_MODE = true;` variable to our `.env` file. Devs can add this to their machines, but the hooks will default to true anyway, so it is not critical.

**In Netlify**, we still need to create `REACT_APP_DEVELOPMENT_MODE = false;`. This will make the production app consume real data, while the dev mode will only use mocked data to avoid burning through our API request limits.

To go in after #15 