### PR TITLE
Nutrient Preferences Form

### DIFF
--- a/nutridine/src/hooks/useSubmitNutrientPreferences.js
+++ b/nutridine/src/hooks/useSubmitNutrientPreferences.js
@@ -15,26 +15,23 @@ const useSubmitNutrientPreferences = (userUid) => {
   const [isSaving, setIsSaving] = useState(false);
 
   function validateMicronutrientInput(value) {
-    // uninitialized values are okay
-    if (value === null || value === "" || value === undefined) {
+    // Value is allowed to be null, undefined, or an empty string
+    if (!value) {
       return true;
     }
-    // decimals + integers okay
-    if (/^\d+(\.\d+)?$/.test(value)) {
-      return true;
-    }
-    return false;
+    // Check if the value contains only digits and (at most) one decimal
+    const regex = /^\d*\.?\d*$/;
+    return regex.test(value);
   }
 
   function validNumericalInput(value) {
-    // uninitialized values are okay
-    if (value === null || value === "") {
+    // Value is allowed to be null, undefined, or an empty string
+    if (!value) {
       return true;
     }
-    if (value > 0 && /^[0-9]+$/.test(value)) {
-      return true;
-    }
-    return false;
+    // Check the value is a positive integer
+    const regex = /^\d*$/;
+    return regex.test(value);
   }
 
   function validateNutrients(nutrientPreferences) {

--- a/nutridine/src/screens/nutrientPreferences/NutrientPreferences.js
+++ b/nutridine/src/screens/nutrientPreferences/NutrientPreferences.js
@@ -124,6 +124,9 @@ export default function NutrientPreferences() {
     }
   };
 
+  const preventSpecialNumericalCharacters = (event) =>
+    ["e", "E", "+", "-"].includes(event.key) && event.preventDefault();
+
   return (
     <Container>
       <VStack>
@@ -171,6 +174,7 @@ export default function NutrientPreferences() {
                     w="90px"
                     value={dailyMaximums.calories || ""}
                     onChange={handleInputChange}
+                    onKeyDown={preventSpecialNumericalCharacters}
                   />
                   <InputRightAddon w="60px">kcal</InputRightAddon>
                 </InputGroup>
@@ -200,6 +204,7 @@ export default function NutrientPreferences() {
                     w="90px"
                     value={dailyMaximums.totalFat || ""}
                     onChange={handleInputChange}
+                    onKeyDown={preventSpecialNumericalCharacters}
                   />
                   <InputRightAddon w="60px">g</InputRightAddon>
                 </InputGroup>
@@ -228,6 +233,7 @@ export default function NutrientPreferences() {
                     w="90px"
                     value={dailyMaximums.cholesterol || ""}
                     onChange={handleInputChange}
+                    onKeyDown={preventSpecialNumericalCharacters}
                   />
                   <InputRightAddon w="60px">mg</InputRightAddon>
                 </InputGroup>
@@ -256,6 +262,7 @@ export default function NutrientPreferences() {
                     w="90px"
                     value={dailyMaximums.sodium || ""}
                     onChange={handleInputChange}
+                    onKeyDown={preventSpecialNumericalCharacters}
                   />
                   <InputRightAddon w="60px">mg</InputRightAddon>
                 </InputGroup>
@@ -284,6 +291,7 @@ export default function NutrientPreferences() {
                     w="90px"
                     value={dailyMaximums.carbs || ""}
                     onChange={handleInputChange}
+                    onKeyDown={preventSpecialNumericalCharacters}
                   />
                   <InputRightAddon w="60px">g</InputRightAddon>
                 </InputGroup>
@@ -312,6 +320,7 @@ export default function NutrientPreferences() {
                     w="90px"
                     value={dailyMaximums.protein || ""}
                     onChange={handleInputChange}
+                    onKeyDown={preventSpecialNumericalCharacters}
                   />
                   <InputRightAddon w="60px">g</InputRightAddon>
                 </InputGroup>
@@ -408,6 +417,7 @@ export default function NutrientPreferences() {
                           w="90px"
                           value={selectedNutrientMaximums[nutrient] || ""}
                           onChange={handleMicroNutrientChange}
+                          onKeyDown={preventSpecialNumericalCharacters}
                         />
                         <InputRightAddon w="60px">
                           {nutrientUnits[nutrientWatchListIDs[nutrient]]}

--- a/nutridine/src/screens/nutrientPreferences/NutrientPreferences.js
+++ b/nutridine/src/screens/nutrientPreferences/NutrientPreferences.js
@@ -135,7 +135,7 @@ export default function NutrientPreferences() {
           alignItems={"center"}
           w="100%"
         >
-          <Heading fontSize={"3xl"} mb="0.25rem">
+          <Heading fontSize={["2xl", "3xl"]} mb="0.25rem">
             Daily Maximums
           </Heading>
           <Divider
@@ -144,7 +144,7 @@ export default function NutrientPreferences() {
             mt="6px"
           />
 
-          <Text maxW="480px" fontSize={"sm"} my="1rem" textAlign={"justify"}>
+          <Text maxW="480px" fontSize={"1rem"} my="1rem" textAlign={"justify"}>
             Please enter your personal daily maximum values to create a
             personalized nutrition facts label. Any values you do not enter,
             will default to the FDA's recommended daily maximums, based on a
@@ -326,7 +326,7 @@ export default function NutrientPreferences() {
         {/* WATCH LIST */}
         <Box mb="2rem">
           <Flex mb="1.5rem" flexDirection="column" alignItems={"center"}>
-            <Heading fontSize={"3xl"} mb="0.25rem">
+            <Heading fontSize={["2xl", "3xl"]} mb="0.25rem">
               Create your Watch List
             </Heading>
             <Divider
@@ -348,6 +348,8 @@ export default function NutrientPreferences() {
               onChange={(e) => handleSelectChange(e.target.value)}
               my="0.5rem"
               maxW="400px"
+              fontFamily={"theme.global.body.fontFamily"}
+              fontSize="1rem"
             >
               {filteredNutrients.map((nutrient) => (
                 <option key={nutrient} value={nutrient}>


### PR DESCRIPTION
Adressing the feedback from #28 .

- Change headings sizes based on viewport size
- Make the select component and heading description have the same font & font size

I didn't understand the request about posting with the letter `e`. This is considered a number from the viewpoint of the `input`, so the user can type it, but the form validation prevents it from ever ebign sent to the DB. 
<img width="655" alt="image" src="https://github.com/SENG480a-NutriDine/webapp/assets/76227136/807b2c46-6c75-4f7e-b73f-c0c90c96f607">

<img width="370" alt="image" src="https://github.com/SENG480a-NutriDine/webapp/assets/76227136/e8d8a7c1-a3fc-48ec-b1bd-9e8513f0a92c">

- The `Select` font wasn't matching our theme, so it was updated. Both the description and select are `1rem`. 
- I tried every trick up my sleeve to update the `<option/>`'s, but nothing was getting applied. Decided there are more important things to work on.